### PR TITLE
Replace `hostname`.chomp with Socket.gethostname

### DIFF
--- a/fluent-mixin-config-placeholders.gemspec
+++ b/fluent-mixin-config-placeholders.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "fluentd"
   gem.add_runtime_dependency "uuidtools", ">= 2.1.5"
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "test-unit"
 end

--- a/lib/fluent/mixin/config_placeholders.rb
+++ b/lib/fluent/mixin/config_placeholders.rb
@@ -1,5 +1,6 @@
 require 'fluent/config'
 require 'uuidtools'
+require 'socket'
 
 module Fluent
   module Mixin
@@ -47,11 +48,11 @@ module Fluent
       def configure(conf)
         # Element#has_key? inserts key name into 'used' list, so we should not use that method...
         hostname = if conf.keys.include?('hostname') && has_replace_pattern?( conf.fetch('hostname') )
-                     `hostname`.chomp
+                     Socket.gethostname
                    elsif conf.keys.include?('hostname')
                      conf['hostname']
                    else
-                     `hostname`.chomp
+                     Socket.gethostname
                    end
 
         placeholders = self.respond_to?(:placeholders) ? self.placeholders : PLACEHOLDERS_DEFAULT

--- a/test/mixin/test_config_placeholders.rb
+++ b/test/mixin/test_config_placeholders.rb
@@ -1,6 +1,10 @@
 require 'helper'
 
 class ConfigPlaceholdersTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
   def create_plugin_instances(conf)
     [
       Fluent::ConfigPlaceholdersTest0Input, Fluent::ConfigPlaceholdersTest1Input, Fluent::ConfigPlaceholdersTest2Input

--- a/test/mixin/test_config_placeholders.rb
+++ b/test/mixin/test_config_placeholders.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'socket'
 
 class ConfigPlaceholdersTest < Test::Unit::TestCase
   def setup
@@ -260,7 +261,7 @@ attr1    ${hostname}
     assert_equal "test.host.local", p1.attr1
 
     # this configuration pattern is to set hostname-attribute of plugins
-    #  when 'myhostname' is host name (result of `hostname` shell command),
+    #  when 'myhostname' is host name (result of Socket.gethostname),
     #  - @hostname is set as 'myhostname.fluentd.local'
     #  - @attr1 should be set as 'myhostname' only, it is default of mixin
     conf2 = %[
@@ -268,7 +269,7 @@ hostname ${hostname}.fluentd.local
 attr1    __HOSTNAME__
 ]
     p2 = Fluent::Test::InputTestDriver.new(Fluent::ConfigPlaceholdersTest3Input).configure(conf2).instance
-    hostname_cmd = `hostname`.chomp
+    hostname_cmd = Socket.gethostname
     assert_equal "#{hostname_cmd}.fluentd.local", p2.hostname
     assert_equal hostname_cmd, p2.attr1
   end


### PR DESCRIPTION
The following error were encountered when using this plugin.
I think that the cause of this is a `hostname` command not installed.

```
unexpected error error="No such file or directory - hostname"
```

So I suggest replace `` `hostname`.chomp `` with `Socket.gethostname` for the following reasons.

- `` `hostname`.chomp `` can not execute unless `hostname` command installed
- Both `Socket.gethostname` and `hostname` command are simple `gethostname(3)` wrapper
- `Socket.gethostname` run anywhere if can run Ruby