### PR TITLE
Adopt v0.14

### DIFF
--- a/lib/fluent/mixin/config_placeholders.rb
+++ b/lib/fluent/mixin/config_placeholders.rb
@@ -90,7 +90,7 @@ module Fluent
           end
         end
 
-        def check_element(map,c)
+        def check_element_override(map,c)
           c.arg = replace(map, c.arg)
           c.keys.each do |k|
             v = c.fetch(k, nil)
@@ -101,7 +101,9 @@ module Fluent
           c.elements.each{|e| check_element(map,e)}
         end
 
-        check_element(mapping,conf)
+        check_element_override(mapping,conf)
+
+        alias :check_element :check_element_override
 
         super
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,7 @@ unless ENV.has_key?('VERBOSE')
   $log = nulllogger
 end
 
+require 'fluent/input'
 require 'fluent/mixin/config_placeholders'
 require_relative 'plugin'
 

--- a/test/mixin/test_config_placeholders.rb
+++ b/test/mixin/test_config_placeholders.rb
@@ -218,7 +218,7 @@ path /path/to/file.log
     require 'uuidtools'
     uuid = UUIDTools::UUID.sha1_create(UUIDTools::UUID_DNS_NAMESPACE, "test.host.local").to_s
 
-    p1, p2, p3 = create_plugin_instances(conf)
+    _p1, _p2, p3 = create_plugin_instances(conf)
     assert_equal "config", p3.conf.elements.first.name
     assert_equal "test.host.local", p3.conf.elements.first.arg
     assert_equal "val1." + uuid, p3.conf.elements.first['var']


### PR DESCRIPTION
- Add missing `fluent/input` require
- Eliminate flood of method overriding warnings
- Clarify unused variables in test with `_`
